### PR TITLE
[agent] Update topics page with disco ball symbol and improved Open S…

### DIFF
--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -48,8 +48,8 @@ export default function TopicsPage() {
 
             <div className="topics-content">
               <div className="callout">
-                <strong>🌐 Open Space Technology</strong><br />
-                Anyone in attendance can put a topic on the agenda. These suggestions help us understand the community's interests and prepare for productive discussions.
+                <strong>🪩 Open Space Technology</strong><br />
+                We use Open Space Technology to co-create the agenda live the morning of the event. Below is the list of what attendees shared with us as they registered about topics they hope to learn about, want to present about and topics to discuss with others at the event. It is important to note this list is not used to "create the agenda" that is done by everyone gathered in person October 24th beginning at 9am.
               </div>
 
               <div className="topics-grid">


### PR DESCRIPTION
…pace Technology description

- Changed symbol from 🌐 to 🪩 (disco ball) for Open Space Technology section
- Updated description to clarify that agenda is co-created live on October 24th at 9am
- Improved language to explain the purpose of the topic list vs actual agenda creation