### PR TITLE
[agent] Revert disco ball symbol back to globe symbol

### DIFF
--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -48,7 +48,7 @@ export default function TopicsPage() {
 
             <div className="topics-content">
               <div className="callout">
-                <strong>🪩 Open Space Technology</strong><br />
+                <strong>🌐 Open Space Technology</strong><br />
                 We use Open Space Technology to co-create the agenda live the morning of the event. Below is the list of what attendees shared with us as they registered about topics they hope to learn about, want to present about and topics to discuss with others at the event. It is important to note this list is not used to "create the agenda" that is done by everyone gathered in person October 24th beginning at 9am.
               </div>
 


### PR DESCRIPTION
- Changed symbol from 🪩 back to 🌐 for Open Space Technology section
- Kept the improved description text