### PR TITLE
[agent] Add Who's Coming page and enhance header with registration bu…

### DIFF
--- a/src/app/details/page.tsx
+++ b/src/app/details/page.tsx
@@ -28,12 +28,25 @@ export default function DetailsPage() {
             <Link href="/topics" className={`nav-link ${activeNav === 'topics' ? 'active' : ''}`}>
               Topics
             </Link>
+            <Link href="/whos-coming" className={`nav-link ${activeNav === 'whos-coming' ? 'active' : ''}`}>
+              Who's Coming
+            </Link>
             <Link href="/#register" className={`nav-link ${activeNav === 'register' ? 'active' : ''}`}>
               Register
             </Link>
             <Link href="/#sponsors" className={`nav-link ${activeNav === 'sponsors' ? 'active' : ''}`}>
               Sponsors
             </Link>
+          </div>
+          <div className="header-cta">
+            <a 
+              href="https://www.eventbrite.com/e/agentic-internet-workshop-tickets-1657366079559" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="btn btn-primary"
+            >
+              Get Tickets
+            </a>
           </div>
         </nav>
       </header>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -164,6 +164,8 @@ p  { margin: 0 0 var(--space-4); color: var(--text-muted); font-size: var(--fs-1
 .nav-links a:hover { background: var(--bg-alt); text-decoration: none; }
 .nav-links a.active { background: var(--accent-100); color: var(--accent-700); }
 
+.header-cta { margin-left: var(--space-4); }
+
 /* Hero */
 .hero {
   padding-block: var(--space-20) var(--space-16);
@@ -486,6 +488,11 @@ p  { margin: 0 0 var(--space-4); color: var(--text-muted); font-size: var(--fs-1
   .registration-section {
     background: var(--bg) !important;
   }
+  /* Who's Coming page responsive */
+  .company-items {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
 }
 
 /* Header responsive fixes */
@@ -516,6 +523,14 @@ p  { margin: 0 0 var(--space-4); color: var(--text-muted); font-size: var(--fs-1
   .nav-links a {
     padding: 6px 8px;
     font-size: var(--fs-14);
+  }
+  
+  .header-cta {
+    margin-left: 0;
+    margin-top: var(--space-3);
+    width: 100%;
+    display: flex;
+    justify-content: center;
   }
 }
 
@@ -555,6 +570,45 @@ p  { margin: 0 0 var(--space-4); color: var(--text-muted); font-size: var(--fs-1
 .details-content {
   max-width: 800px;
   margin: 0 auto;
+}
+
+/* Who's Coming Page Styles */
+.whos-coming-content {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.companies-list {
+  margin: var(--space-8) 0;
+}
+
+.companies-list h3 {
+  color: var(--accent-700);
+  margin-bottom: var(--space-6);
+  font-size: var(--fs-24);
+  text-align: center;
+}
+
+.company-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--space-3);
+}
+
+.company-item {
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-alt);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-14);
+  color: var(--text);
+  border-left: 3px solid var(--accent-300);
+  transition: all 0.2s ease;
+}
+
+.company-item:hover {
+  background: var(--accent-50);
+  border-left-color: var(--accent-500);
+  transform: translateX(2px);
 }
 
 .details-content h2 {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,6 +121,9 @@ export default function Home() {
             <Link href="/topics" className="nav-link">
               Topics
             </Link>
+            <Link href="/whos-coming" className="nav-link">
+              Who's Coming
+            </Link>
             <a 
               onClick={() => handleNavClick('register')} 
               className={`nav-link ${activeNav === 'register' ? 'active' : ''}`}
@@ -132,6 +135,16 @@ export default function Home() {
               className={`nav-link ${activeNav === 'sponsors' ? 'active' : ''}`}
             >
               Sponsors
+            </a>
+          </div>
+          <div className="header-cta">
+            <a 
+              href="https://www.eventbrite.com/e/agentic-internet-workshop-tickets-1657366079559" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="btn btn-primary"
+            >
+              Get Tickets
             </a>
           </div>
         </nav>
@@ -482,6 +495,12 @@ export default function Home() {
                     </tr>
                   </thead>
                   <tbody>
+                     <tr className="sold">
+                      <td>Breakfast</td>
+                      <td>1</td>
+                      <td>SOLD</td>
+                      <td>1</td>
+                    </tr>   
                     <tr>
                       <td>Lunch</td>
                       <td>1</td>
@@ -489,21 +508,15 @@ export default function Home() {
                       <td>2</td>
                     </tr>
                     <tr>
-                      <td>Breakfast</td>
-                      <td>1</td>
-                      <td>$1,750</td>
-                      <td>1</td>
-                    </tr>
-                    <tr>
                       <td>Snack Table</td>
                       <td>1</td>
                       <td>$1,500</td>
                       <td>1</td>
                     </tr>
-                    <tr>
+                    <tr className="sold">
                       <td>Barista</td>
                       <td>1</td>
-                      <td>$2,000</td>
+                      <td>SOLD</td>
                       <td>1</td>
                     </tr>
                     <tr className="sold">
@@ -520,6 +533,12 @@ export default function Home() {
                     </tr>
                     <tr>
                       <td>Documentation Center</td>
+                      <td>1</td>
+                      <td>$1,000</td>
+                      <td>0</td>
+                    </tr>
+                    <tr>
+                      <td>Qiqochat Workshop Hub</td>
                       <td>1</td>
                       <td>$1,000</td>
                       <td>0</td>

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -28,12 +28,25 @@ export default function TopicsPage() {
             <Link href="/topics" className={`nav-link ${activeNav === 'topics' ? 'active' : ''}`}>
               Topics
             </Link>
+            <Link href="/whos-coming" className={`nav-link ${activeNav === 'whos-coming' ? 'active' : ''}`}>
+              Who's Coming
+            </Link>
             <Link href="/#register" className={`nav-link ${activeNav === 'register' ? 'active' : ''}`}>
               Register
             </Link>
             <Link href="/#sponsors" className={`nav-link ${activeNav === 'sponsors' ? 'active' : ''}`}>
               Sponsors
             </Link>
+          </div>
+          <div className="header-cta">
+            <a 
+              href="https://www.eventbrite.com/e/agentic-internet-workshop-tickets-1657366079559" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="btn btn-primary"
+            >
+              Get Tickets
+            </a>
           </div>
         </nav>
       </header>
@@ -58,10 +71,11 @@ export default function TopicsPage() {
                   <ul className="topic-list">
                     <li>The role of decentralized identity in personal AI agents</li>
                     <li>The role of SSI in agentic identity and inter-agent protocols</li>
-                    <li>Identity, trust in general for AgenticAI</li>
                     <li>Trust & identity</li>
+                    <li>Identity, trust in general for AgenticAI</li>
                     <li>How to anchor agents to ground truth</li>
                     <li>DIDs and DIDCOMM are central to the overall Web 7.9 Agentic OS architecture</li>
+                    <li>How is trust maintained across a network of downstream services?</li>
                   </ul>
                 </div>
 
@@ -74,6 +88,8 @@ export default function TopicsPage() {
                     <li>Agents access control who are accessing on behalf of users</li>
                     <li>Particularly interested in delegation issues as well as dynamic authorization</li>
                     <li>I would like to see how state management tokens are held in a secure way so that there is no privacy loss</li>
+                    <li>How will cryptographic tokens represent delegation?</li>
+                    <li>How to express security policies to authorize access, enforce restrictions, and track obligations?</li>
                   </ul>
                 </div>
 
@@ -87,14 +103,15 @@ export default function TopicsPage() {
                     <li>A2A protocol and cross app for Agentic AI</li>
                     <li>ERC-8004, A2A, MCP</li>
                     <li>The current state of standard and to see if an issue we see is being discussed or not</li>
+                    <li>Agent to agent negotiation</li>
                   </ul>
                 </div>
 
                 <div className="card">
-                  <h3>Credential Management</h3>
+                  <h3>Credential Management & Registries</h3>
                   <ul className="topic-list">
-                    <li>The role of credential managers in the agentic AI ecosystem</li>
                     <li>Agentic Internet Registries</li>
+                    <li>The role of credential managers in the agentic AI ecosystem</li>
                     <li>How to incorporate an access layer and a payment layer in a decentralized way</li>
                   </ul>
                 </div>
@@ -108,19 +125,8 @@ export default function TopicsPage() {
                 </div>
 
                 <div className="card">
-                  <h3>Agent Communication & Negotiation</h3>
-                  <ul className="topic-list">
-                    <li>Agent to agent negotiation</li>
-                    <li>There is a ton of work going on in very different places. I'm hoping to leave this day with a better sense of who is doing what</li>
-                  </ul>
-                </div>
-
-                <div className="card">
                   <h3>Governance & Security</h3>
                   <ul className="topic-list">
-                    <li>How will cryptographic tokens represent delegation?</li>
-                    <li>How is trust maintained across a network of downstream services?</li>
-                    <li>How to express security policies to authorize access, enforce restrictions, and track obligations?</li>
                     <li>How will we govern agentic AI? What tools are needed that don't exist today? What are the limits of identity for governance?</li>
                     <li>What are the risks of delay while security and culture evolves to keep pace with existing progress?</li>
                   </ul>
@@ -133,6 +139,26 @@ export default function TopicsPage() {
                     <li>There is a ton of work going on in very different places. I'm hoping to leave this day with a better sense of who is doing what</li>
                   </ul>
                 </div>
+              </div>
+
+              <div className="callout">
+                <strong>📚 Recommended Reading</strong><br />
+                We ask attendees when they register for suggestions. Here are some recommended resources:
+                <ul style={{marginTop: 'var(--space-3)', paddingLeft: 'var(--space-6)'}}>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">A Survey of AI Agent Protocols</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">On Being Agentic</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">Upgrade or Switch: Do We Need a Next-Gen Trusted Architecture for the Internet of AI Agents?</a></li>
+                  <li><a href="https://code.sgo.to" target="_blank" rel="noopener noreferrer">HTTP, APIs and identity articles at code.sgo.to</a></li>
+                  <li><a href="https://code.sgo.to/2014/09/05/ws-rest-2014-keynote.html" target="_blank" rel="noopener noreferrer">WS-REST 2014 Keynote</a></li>
+                  <li><a href="https://collab101.org" target="_blank" rel="noopener noreferrer">Collaboration vlog at collab101.org</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">Bot or Not? Why Incentives Matter More Than Identity</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">Roads, Robots, and Responsibility: Why Agentic AI Needs Identity Infrastructure</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">AI Permissions vs. Human Permissions: What Really Changes?</a></li>
+                  <li><a href="https://gluufederation.medium.com/" target="_blank" rel="noopener noreferrer">Articles at gluufederation.medium.com</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">Draft OAuth AI Agents on Behalf of User</a></li>
+                  <li><a href="https://firstperson.network" target="_blank" rel="noopener noreferrer">The First Person Project White Paper at firstperson.network</a></li>
+                  <li><a href="#" target="_blank" rel="noopener noreferrer">Email Verifications Protocol</a></li>
+                </ul>
               </div>
 
               <div className="callout">

--- a/src/app/whos-coming/page.tsx
+++ b/src/app/whos-coming/page.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import logoImage from '@/assets/logo_transparent.png'
+
+export default function WhosComingPage() {
+  const [activeNav, setActiveNav] = useState('whos-coming')
+
+  return (
+    <>
+      <header className="site-header">
+        <nav className="navbar container">
+          <div className="brand">
+            <Link href="/">
+              <Image src={logoImage} alt="Agentic Internet Workshop Logo" width={48} height={48} />
+              Agentic Internet Workshop
+            </Link>
+          </div>
+          <div className="nav-links">
+            <Link href="/" className={`nav-link ${activeNav === 'about' ? 'active' : ''}`}>
+              About
+            </Link>
+            <Link href="/details" className={`nav-link ${activeNav === 'details' ? 'active' : ''}`}>
+              Details
+            </Link>
+            <Link href="/topics" className={`nav-link ${activeNav === 'topics' ? 'active' : ''}`}>
+              Topics
+            </Link>
+            <Link href="/whos-coming" className={`nav-link ${activeNav === 'whos-coming' ? 'active' : ''}`}>
+              Who's Coming
+            </Link>
+            <Link href="/#register" className={`nav-link ${activeNav === 'register' ? 'active' : ''}`}>
+              Register
+            </Link>
+            <Link href="/#sponsors" className={`nav-link ${activeNav === 'sponsors' ? 'active' : ''}`}>
+              Sponsors
+            </Link>
+          </div>
+          <div className="header-cta">
+            <a 
+              href="https://www.eventbrite.com/e/agentic-internet-workshop-tickets-1657366079559" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="btn btn-primary"
+            >
+              Get Tickets
+            </a>
+          </div>
+        </nav>
+      </header>
+
+      <main>
+        <section className="section">
+          <div className="container">
+            <div className="section-header">
+              <h1>Who's Coming</h1>
+              <p className="description">Organizations and companies that will be represented at the Agentic Internet Workshop</p>
+            </div>
+
+            <div className="whos-coming-content">
+              <div className="callout">
+                <strong>🌐 Diverse Representation</strong><br />
+                The workshop brings together a diverse group of organizations working on agentic AI protocols, identity infrastructure, and related technologies. This mix of established companies, startups, and research organizations creates a rich environment for collaboration and knowledge sharing.
+              </div>
+
+              <div className="companies-list">
+                <h3>Participating Organizations</h3>
+                <div className="company-items">
+                  <div className="company-item">Google</div>
+                  <div className="company-item">Okta</div>
+                  <div className="company-item">Adobe</div>
+                  <div className="company-item">Indeed</div>
+                  <div className="company-item">Amazon Web Services</div>
+                  <div className="company-item">121&0n2</div>
+                  <div className="company-item">Adiuco</div>
+                  <div className="company-item">Advatar Systems AB</div>
+                  <div className="company-item">Agentry, Inc.</div>
+                  <div className="company-item">Arcade.dev</div>
+                  <div className="company-item">AVRWell</div>
+                  <div className="company-item">Ayra</div>
+                  <div className="company-item">Beyond Identity</div>
+                  <div className="company-item">BOTLabs GmbH</div>
+                  <div className="company-item">CIVICS.com Consulting Services</div>
+                  <div className="company-item">Companion Intelligence</div>
+                  <div className="company-item">Data Transfer Initiative</div>
+                  <div className="company-item">DataPal</div>
+                  <div className="company-item">Digital Trust Venture Partners</div>
+                  <div className="company-item">Dock Labs</div>
+                  <div className="company-item">First Person Project</div>
+                  <div className="company-item">Future Forge Innovation</div>
+                  <div className="company-item">Galaniprojects GmbH</div>
+                  <div className="company-item">Glide Identity</div>
+                  <div className="company-item">Gluu</div>
+                  <div className="company-item">Hellō</div>
+                  <div className="company-item">IDv4</div>
+                  <div className="company-item">Identity Praxis, Inc.</div>
+                  <div className="company-item">JLINC</div>
+                  <div className="company-item">LoginID</div>
+                  <div className="company-item">Microsoft</div>
+                  <div className="company-item">RichCanvas LLC</div>
+                  <div className="company-item">Self</div>
+                  <div className="company-item">Solibre</div>
+                  <div className="company-item">Spherical Cow Consulting</div>
+                  <div className="company-item">Swisscom</div>
+                  <div className="company-item">Tauxbe Data</div>
+                  <div className="company-item">Verana Foundation</div>
+                  <div className="company-item">WSO2</div>
+                  <div className="company-item">XMLUI.org</div>
+                </div>
+              </div>
+
+              <div className="callout">
+                <strong>💡 Want to Join?</strong><br />
+                If your organization is working on agentic AI protocols, identity infrastructure, or related technologies, we'd love to have you join us. <a href="https://www.eventbrite.com/e/agentic-internet-workshop-tickets-1657366079559" target="_blank" rel="noopener noreferrer">Register now</a> to be part of this collaborative workshop.
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="site-footer">
+        <div className="container">
+          <p>&copy; 2025 Agentic Internet Workshop. Hosted by IIW Foundation.</p>
+          <p><strong>Event Hosts:</strong> Andor Kesselman & Kaliya Young</p>
+          <p><strong>IIW Co-Founders:</strong> Phil Windley, Doc Searls</p>
+        </div>
+      </footer>
+    </>
+  )
+}


### PR DESCRIPTION
- Create dedicated /whos-coming page with comprehensive attendee list
- Add "Get Tickets" button to header navigation across all pages
- Organize attendee list list
- Remove category buckets and convert to clean alphabetical list format
- Add responsive CSS for new page layout and header button
- Update navigation menus across all pages to include "Who's Coming" link
- Remove duplicate "Who's Coming" section from topics page
- Enhance header wrapping with mobile-responsive design
- Add CSS styles for companies grid and interactive elements