### PR TITLE
Add JLINC as WiFi Sponsor for AIW #2

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -553,9 +553,9 @@ export default function Home() {
                       <td>$2,000</td>
                       <td>1</td>
                     </tr>
-                    <tr>
+                    <tr className="done">
                       <td>Wifi</td>
-                      <td>1</td>
+                      <td>Done</td>
                       <td>$1,500</td>
                       <td>1</td>
                     </tr>
@@ -635,9 +635,9 @@ export default function Home() {
                       <td>$2,000</td>
                       <td>1</td>
                     </tr>
-                    <tr>
+                    <tr className="done">
                       <td>Wifi</td>
-                      <td>1</td>
+                      <td>Done</td>
                       <td>$1,500</td>
                       <td>1</td>
                     </tr>

--- a/src/lib/eventData.ts
+++ b/src/lib/eventData.ts
@@ -437,12 +437,12 @@ export const events: Record<string, Event> = {
       },
       {
         id: 'sponsor-aiw2-5',
-        name: 'WiFi Sponsor',
+        name: 'JLINC',
         tier: 'WiFi',
-        logoUrl: '/sponsors/placeholder.png',
-        websiteUrl: '#',
+        logoUrl: '/sponsors/jlinc.png',
+        websiteUrl: 'https://www.jlinc.com',
         description: 'WiFi Sponsor',
-        isAvailable: true
+        isAvailable: false
       },
       {
         id: 'sponsor-aiw2-6',


### PR DESCRIPTION
## Summary
- Added JLINC as the WiFi sponsor for Agentic Internet Workshop #2
- Updated sponsor configuration to display JLINC logo and information
- Marked WiFi sponsorship as "Done" in both sponsorship tabs

## Changes
- **src/lib/eventData.ts**: Updated WiFi sponsor entry for AIW #2
  - Changed from placeholder to JLINC sponsor details
  - Set `name: 'JLINC'`, `logoUrl: '/sponsors/jlinc.png'`, `websiteUrl: 'https://www.jlinc.com'`
  - Set `isAvailable: false` to mark as sold
  
- **src/app/page.tsx**: Updated sponsorship tables
  - Added `className="done"` to WiFi sponsor rows
  - Changed availability from "1" to "Done" in both sponsor tabs

## Notes
- JLINC logo (`/sponsors/jlinc.png`) already exists from AIW #1, no new assets needed
- Sponsorship pricing remains $1,500
- Includes 1 event pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)