### PR TITLE
feat(events): archive AIW2, scaffold AIW3 as current event

### DIFF
--- a/src/app/details/page.tsx
+++ b/src/app/details/page.tsx
@@ -41,14 +41,16 @@ export default function DetailsPage() {
             </Link>
           </div>
           <div className="header-cta">
-            <a 
-              href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator" 
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="btn btn-primary"
-            >
-              Get Tickets
-            </a>
+            {event.details.registrationUrl && (
+              <a
+                href={event.details.registrationUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-primary"
+              >
+                Get Tickets
+              </a>
+            )}
           </div>
         </nav>
       </header>
@@ -240,9 +242,13 @@ export default function DetailsPage() {
               <div className="cta-section">
                 <h2>Ready to Join?</h2>
                 <p>Register now for this groundbreaking workshop on agentic protocols</p>
-                <a href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator" className="btn btn-primary">
-                  Register on Eventbrite
-                </a>
+                {event.details.registrationUrl ? (
+                  <a href={event.details.registrationUrl} className="btn btn-primary">
+                    Register on Eventbrite
+                  </a>
+                ) : (
+                  <p><em>Registration opens soon.</em></p>
+                )}
               </div>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
     const generateQR = async () => {
       try {
         // Use Eventbrite registration URL from event data
-        const registrationUrl = event.details.registrationUrl || 'https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator'
+        const registrationUrl = event.details.registrationUrl || ''
         const qrDataUrl = await QRCode.toDataURL(registrationUrl, {
           width: 200,
           margin: 2,
@@ -162,14 +162,16 @@ export default function Home() {
             </a>
           </div>
           <div className="header-cta">
-            <a 
-              href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator"
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="btn btn-primary"
-            >
-              Get Tickets
-            </a>
+            {event.details.registrationUrl && (
+              <a
+                href={event.details.registrationUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-primary"
+              >
+                Get Tickets
+              </a>
+            )}
           </div>
         </nav>
       </header>
@@ -186,9 +188,9 @@ export default function Home() {
               IIW-Inspired™ Event • {event.date}
             </div>
             
-            <h1>Agentic Internet Workshop #2</h1>
-            <p className="lede">Friday May 1st 2026</p>
-            <p className="lede">For our 2nd event we continue to build on the 20+ year legacy of Internet Identity Workshop. We are advancing the next generation of protocols for how agents connect, collaborate, and preserve human judgment in an agentic world.</p>
+            <h1>Agentic Internet Workshop #{event.eventNumber}</h1>
+            <p className="lede">{event.date}</p>
+            <p className="lede">Building on the 20+ year legacy of Internet Identity Workshop, we are advancing the next generation of protocols for how agents connect, collaborate, and preserve human judgment in an agentic world.</p>
             
             <div className="hero-highlights">
               <div className="highlight-item">
@@ -225,33 +227,32 @@ export default function Home() {
             <h2>Register for the Workshop</h2>
             <p className="mw-tight">Join protocol innovators, researchers, and builders working on the future of agentic systems. Registration requires submission of your current work in the AI Agent/Protocol space.</p>
 
-            <div className="callout" style={{marginTop: 'var(--space-6)', marginBottom: 'var(--space-4)'}}>
-              <strong>🔗 Internet Identity Workshop #42</strong><br />
-              Internet Identity Workshop #42 is happening April 28-30th in the same venue. We are considering doing an interop day parallel to IIW on April 30th.
-            </div>
+            <p className="mw-tight" style={{marginBottom: 'var(--space-6)'}}>See the <a href="/bop/1.pdf" target="_blank" rel="noopener noreferrer">Book of Proceedings for the First Agentic Internet Workshop</a>. Visit the <a href="/events/1">legacy AIW #1 site</a> and <a href="/events/2">AIW #2 site</a> for more information about our previous events.</p>
 
-            <p className="mw-tight" style={{marginBottom: 'var(--space-6)'}}>See the <a href="/bop/1.pdf" target="_blank" rel="noopener noreferrer">Book of Proceedings for the First Agentic Internet Workshop</a>. Visit the <a href="/events/1">legacy AIW #1 site</a> for more information about our first event.</p>
-            
-            <div className="qr-section">
-              {qrCodeUrl ? (
-                <Image 
-                  src={qrCodeUrl} 
-                  alt="Registration QR Code" 
-                  width={200} 
-                  height={200}
-                  style={{ borderRadius: 'var(--radius-md)' }}
-                />
-              ) : (
-                <div className="qr-placeholder">
-                  <div>
-                    <div>📱 QR Code</div>
-                    <div>Loading...</div>
+            {event.details.registrationUrl ? (
+              <div className="qr-section">
+                {qrCodeUrl ? (
+                  <Image
+                    src={qrCodeUrl}
+                    alt="Registration QR Code"
+                    width={200}
+                    height={200}
+                    style={{ borderRadius: 'var(--radius-md)' }}
+                  />
+                ) : (
+                  <div className="qr-placeholder">
+                    <div>
+                      <div>📱 QR Code</div>
+                      <div>Loading...</div>
+                    </div>
                   </div>
-                </div>
-              )}
-              <a href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator" className="btn btn-primary" target="_blank" rel="noopener noreferrer">Register Now</a>
-              <p className="small">Pricing starts at $150 for independents/startups</p>
-            </div>
+                )}
+                <a href={event.details.registrationUrl} className="btn btn-primary" target="_blank" rel="noopener noreferrer">Register Now</a>
+                <p className="small">Pricing starts at $150 for independents/startups</p>
+              </div>
+            ) : (
+              <p className="mw-tight"><em>Registration opens soon. Check back for details.</em></p>
+            )}
           </div>
         </section>
 

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -44,7 +44,7 @@ export default function TopicsPage() {
           </div>
           <div className="header-cta">
             <a
-              href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator"
+              href={event.details.registrationUrl || '#'}
               target="_blank"
               rel="noopener noreferrer"
               className="btn btn-primary"

--- a/src/app/whos-coming/page.tsx
+++ b/src/app/whos-coming/page.tsx
@@ -44,7 +44,7 @@ export default function WhosComingPage() {
           </div>
           <div className="header-cta">
             <a
-              href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator"
+              href={event.details.registrationUrl || '#'}
               target="_blank"
               rel="noopener noreferrer"
               className="btn btn-primary"

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -83,7 +83,7 @@ export function SiteHeader({ event, activeNav = 'about', onNavClick }: SiteHeade
         <div className="header-cta">
           {!isArchived ? (
             <a
-              href="https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator"
+              href={event.details.registrationUrl || '#'}
               target="_blank"
               rel="noopener noreferrer"
               className="btn btn-primary"

--- a/src/lib/eventData.ts
+++ b/src/lib/eventData.ts
@@ -243,7 +243,7 @@ export const events: Record<string, Event> = {
       state: 'CA',
       zipCode: '94043'
     },
-    status: 'current',
+    status: 'archived',
     topics: [
       {
         id: 'aiw2-topic-1',
@@ -565,6 +565,93 @@ export const events: Record<string, Event> = {
     schedule: [],
     details: {
       registrationUrl: 'https://www.eventbrite.com/e/agentic-internet-workshop-2-tickets-1976356257769?aff=oddtdtcreator',
+      contactEmail: 'phil@windley.org',
+      capacity: 200,
+      isRegistrationOpen: false
+    }
+  },
+  '3': {
+    eventId: '3',
+    eventNumber: 3,
+    date: 'TBD',
+    dateISO: '',
+    location: {
+      name: 'Computer History Museum',
+      address: '1401 N Shoreline Blvd',
+      city: 'Mountain View',
+      state: 'CA',
+      zipCode: '94043'
+    },
+    status: 'current',
+    topics: [],
+    attendees: [],
+    sponsors: [
+      {
+        id: 'sponsor-aiw3-1',
+        name: 'Lunch Sponsor',
+        tier: 'Lunch',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'Lunch Sponsor',
+        isAvailable: true
+      },
+      {
+        id: 'sponsor-aiw3-2',
+        name: 'Breakfast Sponsor',
+        tier: 'Breakfast',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'Breakfast Sponsor',
+        isAvailable: true
+      },
+      {
+        id: 'sponsor-aiw3-3',
+        name: 'Snack Table Sponsor',
+        tier: 'Snack Table',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'Snack Table Sponsor',
+        isAvailable: true
+      },
+      {
+        id: 'sponsor-aiw3-4',
+        name: 'Barista Sponsor',
+        tier: 'Barista',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'Barista Sponsor',
+        isAvailable: true
+      },
+      {
+        id: 'sponsor-aiw3-5',
+        name: 'WiFi Sponsor',
+        tier: 'WiFi',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'WiFi Sponsor',
+        isAvailable: true
+      },
+      {
+        id: 'sponsor-aiw3-6',
+        name: 'Open Gifting Sponsor',
+        tier: 'Open Gifting',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'Open Gifting Sponsor',
+        isAvailable: true
+      },
+      {
+        id: 'sponsor-aiw3-7',
+        name: 'Documentation Center Sponsor',
+        tier: 'Documentation Center',
+        logoUrl: '/sponsors/placeholder.png',
+        websiteUrl: '#',
+        description: 'Documentation Center Sponsor',
+        isAvailable: true
+      }
+    ],
+    schedule: [],
+    details: {
       contactEmail: 'phil@windley.org',
       capacity: 200,
       isRegistrationOpen: false


### PR DESCRIPTION
- Set event '2' status to archived
- Add event '3' skeleton (status=current, date TBD, all sponsor slots open)
- Replace all hardcoded AIW2 Eventbrite URLs with dynamic event.details.registrationUrl
- Conditionally hide registration CTA when no registrationUrl is set
- Update hero section title/date to use event data dynamically