### PR TITLE
feat: archive AIW2, launch AIW3

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -33,7 +33,7 @@ export function SiteHeader({ event, activeNav = 'about', onNavClick }: SiteHeade
           <EventLink href="/">
             <Image src={logoImage} alt="Agentic Internet Workshop Logo" width={48} height={48} />
             <span className="brand-text">
-              Agentic Internet Workshop{isArchived ? ` #${event.eventNumber}` : ''}
+              Agentic Internet Workshop #{event.eventNumber}
               {isArchived && <span className="brand-archived"> (Archived)</span>}
             </span>
           </EventLink>


### PR DESCRIPTION
## Summary

- Archives AIW2 (status → `archived`) and adds AIW3 skeleton as the new current event
- AIW3 has date TBD, same CHM location, 7 open sponsor slots, empty attendees/topics
- Replaces all hardcoded AIW2 Eventbrite URLs with `event.details.registrationUrl` — CTAs are conditionally hidden when no URL is set
- Hero section title and date now rendered dynamically from event data
- Brand header always shows event number (e.g. "Agentic Internet Workshop #3")
- Also includes updated AWS lunch sponsor logo (from previous commit)

## Test plan

- [ ] Home page shows "Agentic Internet Workshop #3" in header and hero
- [ ] "Get Tickets" / "Register Now" buttons are hidden (no registrationUrl on AIW3 yet)
- [ ] `/events/1` and `/events/2` archive pages still render correctly
- [ ] Sponsors tab shows 7 available slots for AIW3
- [ ] Topics and Who's Coming pages show empty state for AIW3

🤖 Generated with [Claude Code](https://claude.com/claude-code)